### PR TITLE
Support API returning undefined body on Droplet Destroy

### DIFF
--- a/lib/digio-api.js
+++ b/lib/digio-api.js
@@ -25,7 +25,7 @@ var digio_api = function (token) {
         if (err) return callback(err)
         if (res.statusCode >= 400) return (typeof body !== 'object' ? callback(body_error, body) : callback(body))
         if (method == 'HEAD') return callback(null, res.headers)
-        if (body === '') return callback(null, {})
+        if (body === '' || body === undefined) return callback(null, {})
         else if (typeof body !== 'object') return callback(body_error, body)
         else callback(null, body)
       })


### PR DESCRIPTION
Previously would return 'body_error' on successful destroy.
